### PR TITLE
Fix incorrect GitHub Pages URL in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ If you want to build fonts manually on your own computer:
 * `make test` will run [FontBakery](https://github.com/googlefonts/fontbakery)'s quality assurance tests.
 * `make proof` will generate HTML proof files.
 
-The proof files and QA tests are also available automatically via GitHub Actions - look at https://paper-design.github.io/paper-mono.git.
+The proof files and QA tests are also available automatically via GitHub Actions - look at https://paper-design.github.io/paper-mono.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Fixed typo in readme.md where the GitHub Pages URL incorrectly included `.git` extension
- The URL should point to the website (https://paper-design.github.io/paper-mono) not the repository

## Test plan
- [x] Verified the corrected URL format for GitHub Pages
- [x] Confirmed the change only affects documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)